### PR TITLE
fix for c94ffd1 so that it actually compiles

### DIFF
--- a/sys/vaxstand/uda.c
+++ b/sys/vaxstand/uda.c
@@ -152,7 +152,7 @@ udcmd(op, io)
 	for (;;) {
 		if (u->uda1_ca.ca_cmdint)
 			u->uda1_ca.ca_cmdint = 0;
-		if (u->uda_ca.ca_rspdc & MSCP_OWN)
+		if (u->uda1_ca.ca_rspdsc & MSCP_OWN)
 			continue;
 		u->uda1_ca.ca_rspint = 0;
 		if (mp->mscp_opcode == (op | M_OP_END))


### PR DESCRIPTION
change has been tested on a VAXStation 3200 (KA650) using both RQDX3 and CMD CQD-220 MSCP disk controllers. No issues noticed on either.